### PR TITLE
Trivial fixes for koans_linear_classifier

### DIFF
--- a/sources/koans_linear_classifier.ipynb
+++ b/sources/koans_linear_classifier.ipynb
@@ -239,7 +239,7 @@
    "source": [
     "# この2つの群を分離する分離直線を学習する\n",
     "\n",
-    "ロスは$$ (-tanh(t*l) + 1)/2) $$ あたりが良いらしい。"
+    "ロスは$$ (-tanh(t*l) + 1)/2 $$ あたりが良いらしい。"
    ]
   },
   {
@@ -342,11 +342,11 @@
    "source": [
     "# ここのセルのFAILEDが無いように！\n",
     "\n",
-    "assertEquals(t_arr[0], -1)\n",
-    "assertEquals(t_arr[9], -1)\n",
+    "assertEquals(-1, t_arr[0])\n",
+    "assertEquals(-1, t_arr[9])\n",
     "\n",
-    "assertEquals(t_arr[10], 1)\n",
-    "assertEquals(t_arr[19], 1)"
+    "assertEquals(1, t_arr[10])\n",
+    "assertEquals(1, t_arr[19])"
    ]
   },
   {
@@ -459,7 +459,7 @@
     }
    ],
    "source": [
-    "assertEquals(actual[0], 1.40)"
+    "assertEquals(1.40, actual[0])"
    ]
   },
   {
@@ -562,8 +562,8 @@
     }
    ],
    "source": [
-    "assertEquals(res_a[0], -0.779)\n",
-    "assertEquals(res_b[0], 4.6)\n"
+    "assertEquals(-0.779, res_a[0])\n",
+    "assertEquals(4.6, res_b[0])\n"
    ]
   },
   {

--- a/sources/koans_linear_classifier_answer.ipynb
+++ b/sources/koans_linear_classifier_answer.ipynb
@@ -239,7 +239,7 @@
    "source": [
     "# この2つの群を分離する分離直線を学習する\n",
     "\n",
-    "ロスは$$ (-tanh(t*l) + 1)/2) $$ あたりが良いらしい。"
+    "ロスは$$ (-tanh(t*l) + 1)/2 $$ あたりが良いらしい。"
    ]
   },
   {
@@ -338,11 +338,11 @@
     }
    ],
    "source": [
-    "assertEquals(t_arr[0], -1)\n",
-    "assertEquals(t_arr[9], -1)\n",
+    "assertEquals(-1, t_arr[0])\n",
+    "assertEquals(-1, t_arr[9])\n",
     "\n",
-    "assertEquals(t_arr[10], 1)\n",
-    "assertEquals(t_arr[19], 1)"
+    "assertEquals(1, t_arr[10])\n",
+    "assertEquals(1, t_arr[19])"
    ]
   },
   {
@@ -451,7 +451,7 @@
     }
    ],
    "source": [
-    "assertEquals(actual[0], 1.40)"
+    "assertEquals(1.40, actual[0])"
    ]
   },
   {
@@ -554,8 +554,8 @@
     }
    ],
    "source": [
-    "assertEquals(res_a[0], -0.779)\n",
-    "assertEquals(res_b[0], 4.6)\n"
+    "assertEquals(-0.779, res_a[0])\n",
+    "assertEquals(4.6, res_b[0])\n"
    ]
   },
   {


### PR DESCRIPTION
細かい修正です。
- 説明文中、括弧の対応が取れていない
- `assertEquals()` の actual と expected が逆で、エラーメッセージがわかりにくい

あと、直接修正はしませんでしたが、「距離を表すコンピューテーショングラフ lを求めよ」のタスクで、実際に求めるのは距離に符号がついたもの(直線のどちら側にあるかを表す)なので、その説明があるとよいと思いました。
